### PR TITLE
All non-zero exits to exit zero

### DIFF
--- a/modules/run_trycycler_cluster.nf
+++ b/modules/run_trycycler_cluster.nf
@@ -2,6 +2,8 @@ process trycycler_cluster {
   tag "CLUSTERING CONTIGS: ${barcode}"
   container 'quay.io/biocontainers/trycycler:0.5.4--pyhdfd78af_0'
 
+  errorStrategy 'ignore' // Ignore the error status
+
   input:
   tuple val(barcode), path(unicycler_assembly), path(flye_assembly), path(trimmed_fq)
 
@@ -15,6 +17,6 @@ process trycycler_cluster {
     --reads ${barcode}_trimmed.fastq.gz \\
     --out_dir ${barcode}_cluster \\
     --min_contig_len ${params.trycycler_min_contig_length} \\
-    --threads ${task.cpus}
+    --threads ${task.cpus}  || true
   """
 }


### PR DESCRIPTION
- Tested barcodes13 and 14 which throw segmentation fault in run_trycycler_clustering.nf process 
- Irrespective what the error is, the process always returns a success (exit status 0)
- Previous efforts to capture specific exit status (e.g. 139 for segmentation fault) using

```
#exit_status=\$?
  echo "THE EXIT STATUS IS \$exit_status"

  if [ \$exit_status -eq 139 ]; then
     echo "Segmentation fault encountered \$exit_status, exiting with status 0 to continue pipeline"
     exit 0
  else
     exit \$exit_status
  fi
```
did not seem to work

