### PR TITLE
trycycler cluster issue workover, avoid building the tree; don't call the function

### DIFF
--- a/modules/run_trycycler_cluster.nf
+++ b/modules/run_trycycler_cluster.nf
@@ -1,20 +1,29 @@
 process trycycler_cluster {
   tag "CLUSTERING CONTIGS: ${barcode}"
-  container 'quay.io/biocontainers/trycycler:0.5.4--pyhdfd78af_0'
 
   input:
   tuple val(barcode), path(unicycler_assembly), path(flye_assembly), path(trimmed_fq)
 
   output:
-  tuple val(barcode), path("*"), emit: trycycler_cluster
+  tuple val(barcode), path("*_cluster"), emit: trycycler_cluster
 
   script: 
   """
+
+  # This is a local insatllation of trycycler in which we have hashed the function "#build_tree(...)" in the source-code and installed the tool. We need to create a singularity image of this version of trycycler. Details in the PR    
+  base_path_for_tools=/scratch/er01/ndes8648/pipeline_work/nextflow/PIPE-4747/github_repos/self_testing/trycycler_installation/local_copy_and_directly_from_github
+  export PATH=$PATH:\${base_path_for_tools}/mash-Linux64-v2.3:\${base_path_for_tools}/minimap2:\${base_path_for_tools}/miniasm:\${base_path_for_tools}
+  export R_LIBS="/scratch/er01/npd561"
+
   trycycler cluster \\
     --assemblies ${barcode}_unicycler_assembly/assembly.fasta ${barcode}_flye_assembly/assembly.fasta \\
     --reads ${barcode}_trimmed.fastq.gz \\
     --out_dir ${barcode}_cluster \\
     --min_contig_len ${params.trycycler_min_contig_length} \\
     --threads ${task.cpus}
+
+ 
   """
+  
+
 }

--- a/test/run_test.sh
+++ b/test/run_test.sh
@@ -15,6 +15,7 @@
 # Load version of nextflow with plug-in functionality enabled 
 module load nextflow/24.04.1 
 module load singularity 
+module load R/4.3.1
 
 # Define inputs 
 #in= #path to your input directory


### PR DESCRIPTION
What is the `segmentation fault` issue 
-	Some of the tested samples e.g. `barcode13, barcode14 etc` displayed the following issue in the script `modules/run_trycycler_cluster.nf`
 ```
 *** caught segfault *** 
 address 0x38, cause 'memory not mapped' 
```
-	The other samples ran seamlessly without the above error.
-	A [previous issue](https://github.com/rrwick/Trycycler/issues/48) logged on the Trycycler github is identical to what was observed in our pipeline.
-	The author has left the issue unresolved with a reasoning that it originates from the `R-package ape` but they have suggest the following possible solution to try :
o	Reinstalling R's [ape package](https://cran.r-project.org/web/packages/ape/).
o	Using ape's [bionj](https://search.r-project.org/CRAN/refmans/ape/html/bionj.html) function instead. This would require replacing fastme.bal with bionj in Trycycler's cluster.py file (in the create_tree_script function).

**The first thing which I  tried is the above options**
Local installation of trycycler from source on NCI-Gadi to check if updated dependencies (e.g. R package - ape as suggested in the [Trycycler repo issue](https://github.com/rrwick/Trycycler/issues/48#issuecomment-1467105579)) can solve this problem

**Trycycler installation using source** 
1.	git clone https://github.com/rrwick/Trycycler.git 

-	pip3 install ./Trycycler 

Note that the above command installed Trycycler itself and the Python packages it needs ([Edlib](https://github.com/Martinsos/edlib/tree/master/bindings/python), [NumPy](http://www.numpy.org/) and [SciPy](https://www.scipy.org/)). It did not install the external tools that Trycycler requires. For those, please look at the [Software requirements](https://github.com/rrwick/Trycycler/wiki/Software-requirements) page.

**Dependencies** - [Software requirements](https://github.com/rrwick/Trycycler/wiki/Software-requirements) 
 
**Minisasm/minimap2** : https://github.com/lh3/miniasm 
•	git clone https://github.com/lh3/minimap2 && (cd minimap2 && make)  
o	Installation worked 
o	Executable: $ PATH/minimap2/minimap2 
 
•	git clone https://github.com/lh3/miniasm  && (cd miniasm  && make)  
o	Installation worked 
o	Executable: $PATH/miniasm/miniasm 

**Mash**: https://mash.readthedocs.io/en/latest/ 
-	wget https://github.com/marbl/Mash/releases/download/v2.3/mash-Linux64-v2.3.tar 
-	tar -xvf mash-Linux64-v2.3.tar 
-	cd mash-Linux64-v2.3 
o	Installation worked 
o	Executable: $PATH/mash-Linux64-v2.3/mash  


**MUSCLE**: https://drive5.com/muscle/downloads_v3.htm  
o	wget https://drive5.com/muscle/downloads3.8.31/muscle3.8.31_i86linux64.tar.gz 
o	tar -zxvf muscle3.8.31_i86linux64.tar.gz 
Installation worked 
Executable: $PATH/muscle3.8.31_i86linux64 

**R with phylogenetics packages**  (**This part was accomplished with Nathanial’s assistance** Thanks @natbutter :-))
```
module load R/4.3.1 intel-compiler/2021.2.0
Rscript -e 'install.packages("ape", repos=https://cloud.r-project.org/, lib="/scratch/er01/npd561")'
library(ape,lib="/scratch/er01/ npd561")

Rscript -e 'install.packages("phangorn", repos=https://cloud.r-project.org/, lib="/scratch/er01/npd561")'
library(ape,lib="/scratch/er01/ npd561")
```
The above accomplished a complete installation of the [Trycycler software from source](https://github.com/rrwick/Trycycler/wiki/Installation) with the latest versions of the packages `ape` and ` phangorn `  

The pipeline was re-run for samples `barcode13 and barcode14` and this displayed a more specific error 
```
Error in fastme.bal(distances) :  
    cannot build ME tree with less than 3 observations 
```
Next
o	The software Trycycler was re-installed from source again by replacing `fastme.bal with bionj in Trycycler's cluster.py file (in the create_tree_script function).` as suggested by the author
 
The above error was not resolved using bionj 
```
Error in bionj(distances) :  
    cannot build a BIONJ tree with less than 3 observations 
```

**Next**
_At this point, a different thought process was applied -_

A previously observed fact is : 
-	Although the run_trycycler_clustering,nf process threw an error for certain samples, the OUTPUT REQUIRED for the subsequent Trycycler steps was always generated (and is verified to be correct)
-	The outout from this step is
o	contigs.phylip: a matrix of the Mash distances between all contigs in [PHYLIP format](https://www.mothur.org/wiki/Phylip-formatted_distance_matrix).
o	contigs.newick: a [FastME](https://academic.oup.com/mbe/article/32/10/2798/1212138) tree of the contigs built from the distance matrix. This can be visualised in a phylogenetic tree viewer such as [FigTree](http://tree.bio.ed.ac.uk/software/figtree/), [Dendroscope](http://dendroscope.org/) or [Archaeopteryx](https://sites.google.com/site/cmzmasek/home/software/archaeopteryx).
o	One directory for each of the clusters: cluster_001, cluster_002, etc. These directories will each contain a subdirectory named 1_contigs which includes the FASTA files for the contigs in the cluster.
Of the above three, the only output which is carried forward and used by the next ([Trycycler reconciliation step](https://github.com/rrwick/Trycycler/wiki/Reconciling-contigs)) are the subdirectories for each of your good clusters, each of which contains a 1_contigs subdirectory. THESE ARE ALWAYS GENERATED and the correctness of the final assemblies from this for all barcodes (including the problematic ones) has already been confirmed.
o	The other output which is ` contigs.phylip` needed to generate the third output i.e. contigs.newick (which throws the error for certain samples) is for visualisation purposes only (if needed – not a requirement for our pipeline)

**_So, this the best solution for the segmentation fault issue was thus identified to be as follows:_** 
•	HASH OUT the module inside `build_tree` in the python script -` cluster.py` in the trycyler package 
      `#build_tree(seq_names, seqs, depths, matrix, args.out_dir, cluster_numbers)`. Thus trycycler DOES NOT CREATE THE TREE (which is not used in subsequent steps) and thus **avoids throwing the error**.
•	The software Trycycler was re-installed from source again with the `build_tree` module hashed out.
•	All 17 samples were included in a single run and a multiqc_report.html file was successfully generated.

**What is pending**
1.	Convert the above `trycyler from source installation` into a singularity image and use it to test the pipeline
2.	.nextflow/history.lock
-	When I pull the latest version of the pipeline and try to execute it, I am unable to proceed due to the following error
`.nextflow/history.lock (no such file or directory)`
-	I have tried a few options as suggested by google and chatgpt but it has not worked.
-	The testing of the R-solution was done in one of my older local versions of the pipeline. Once the lock issue is sorted, the tesing can be finalised in the most recent version.