### PR TITLE
BUG: Improve tree and heatmap rendering

### DIFF
--- a/bin/create_phylogeny_And_heatmap.r
+++ b/bin/create_phylogeny_And_heatmap.r
@@ -107,20 +107,25 @@ p_names <- tree$tip.label %>%
   coord_cartesian(clip = "off")
 
 # Generate plot ----
+# Set plot size dynamically
+n <- ncol(combined_heatmap)
+l <- length(tree$tip.label)
+
+# used linear eq. (mx + b) to find scaling factor between nrow 17 and 87, where
+# x is the number of genes
+name_width <- -9/560 * n + 993/560
+tree_width <- -3/560 * n + 331/560
+  
 # Align tree, names, and heatmap with aplot  
 main <-
   p_heat %>% 
-  aplot::insert_left(p_names, width = 1.2) %>%
-  aplot::insert_left(p_tree, width = 0.4)
-
-# Set plot size dynamically
-n <- nrow(combined_heatmap)
-l <- length(tree$tip.label)
-
-WIDTH = 600 + n * 30 # tree and names = 600px + dynamic based on genes
-HEIGHT = 100 + l * 30 # dynamic padding for gene names at the top
+  aplot::insert_left(p_names, width = name_width) %>%
+  aplot::insert_left(p_tree, width = tree_width)
 
 # Save to file ----
+WIDTH = 800 + (n * 10) # tree and names = 800px + dynamic based on genes
+HEIGHT = 100 + l * 30 # dynamic padding for gene names at the top
+
 png("combined_plot_mqc.png", width = WIDTH, height = HEIGHT)
 main
 dev.off()

--- a/bin/create_phylogeny_And_heatmap.r
+++ b/bin/create_phylogeny_And_heatmap.r
@@ -24,6 +24,18 @@ heatmap_data2 <- read.table(abricate_gene_matrix, header = TRUE, sep = "\t", row
 
 rm(abricate_gene_matrix, amrfinderplus_gene_matrix, tree_path)
 
+if (ncol(heatmap_data1) + ncol(heatmap_data2) == 0) {
+  # Plot only the tree if no amr data
+  WIDTH = 800
+  HEIGHT = 100 + length(tree$tip.label) * 30
+  png("combined_plot_mqc.png", width = WIDTH, height = HEIGHT)
+  ggtree(tree, size = 1) + 
+    theme_tree2() +
+    geom_tiplab(align = T, as_ylab = T, size = 12)
+  dev.off()
+  stop("No AMR genes detected, plotting phylogeny only")
+}
+
 # Match labels ----
 # Find names that already match across data. These are likely the reference seqs. 
 # IDing here will ensure matching labels are not manipulated. Also to prevent
@@ -74,7 +86,8 @@ row.names(heatmap_data2) <- ifelse(
   heatmap2_names$tip_name[idx]
 )
 
-# Doesn't matter if either heatmap have null results
+# Doesn't matter if either heatmap have null results. If no data in total,
+# plot tree only above
 combined_heatmap <- cbind(heatmap_data1, heatmap_data2)
 rm(heatmap_data1, heatmap_data2, heatmap1_names, heatmap2_names, tree_names)
 

--- a/bin/create_phylogeny_And_heatmap.r
+++ b/bin/create_phylogeny_And_heatmap.r
@@ -31,7 +31,7 @@ tree <- read.tree(full_path)
 
 ## Heatmap for AMR genes
 # Read first heatmap data 
-heatmap_data1 <- read.table(amrfinderplus_gene_matrix, header = TRUE, sep = "\t", row.names = 1)
+heatmap_data1 <- read.table(amrfinderplus_gene_matrix, header = TRUE, sep = "\t", row.names = 1, quote = "")
 
 # Read second heatmap data
 heatmap_data2 <- read.table(abricate_gene_matrix, header = TRUE, sep = "\t", row.names = 1)

--- a/bin/create_phylogeny_And_heatmap.r
+++ b/bin/create_phylogeny_And_heatmap.r
@@ -5,158 +5,122 @@ library(phytools)
 library(tidyverse)
 library(ggtree)
 library(ape)
-library(conflicted)
+library(aplot) # For aligning plots
 
 Sys.setenv(FONTCONFIG_CACHE = "~/.cache/fontconfig")
 
 # Get command-line arguments
 args <- commandArgs(trailingOnly = TRUE)
 
-phylogeny_tree_base_path <- args[1]
+tree_path <- args[1]
 amrfinderplus_gene_matrix <- args[2]
 abricate_gene_matrix <- args[3]
 
+# Read in tree and heatmap files ----
+tree <- ggtree::read.tree(tree_path)
 
-# Open a PNG graphics device
-png(filename = "combined_plot_mqc.png", width = 2000, height = 800)
-
-
-## Read Phylogeny tree
-relative_path_to_tree <- "Results_tree/Species_Tree/SpeciesTree_rooted.txt"
-## Contruct full path to tree
-full_path <- file.path(phylogeny_tree_base_path, relative_path_to_tree)
-
-#tree <- read.tree("results/phylogeny/output/Results_tree/Species_Tree/SpeciesTree_rooted.txt")
-tree <- read.tree(full_path)
-
-## Heatmap for AMR genes
-# Read first heatmap data 
 heatmap_data1 <- read.table(amrfinderplus_gene_matrix, header = TRUE, sep = "\t", row.names = 1, quote = "")
-
-# Read second heatmap data
 heatmap_data2 <- read.table(abricate_gene_matrix, header = TRUE, sep = "\t", row.names = 1)
 
-# Format ids
-format_row_names <- function(data) {
-  rownames(data) <- gsub("\\s+", "_", rownames(data))
-  rownames(data) <- gsub(",", "_", rownames(data))
-  rownames(data) <- gsub("\\(", "", rownames(data))
-  rownames(data) <- gsub("\\)", "", rownames(data))
-  rownames(data) <- trimws(rownames(data), which = "right", whitespace = "_")
-  return(data)
+rm(abricate_gene_matrix, amrfinderplus_gene_matrix, tree_path)
+
+# Match labels ----
+# Find names that already match across data. These are likely the reference seqs. 
+# IDing here will ensure matching labels are not manipulated. Also to prevent
+# messy matches with duplicate prefixes
+l <- list(tree$tip.label, row.names(heatmap_data1), row.names(heatmap_data2))
+matching_names <- Reduce(intersect, l)
+
+add_prefix <- function(names) {
+  # Create a dataframe with the original sequence names and an extra column 
+  # with the prefix. Prefix will be used to match names across datasets
+  names %>%
+    as.data.frame() %>%
+    mutate(prefix = gsub("_.+", "", .))
 }
 
-# Format row names for both heatmaps
-heatmap_data1 <- format_row_names(heatmap_data1)
-heatmap_data2 <- format_row_names(heatmap_data2)
+# Create dataframes to replace row.names of heatmap data
+tree_names <- 
+  add_prefix(tree$tip.label) %>%
+  rename(tip_name = ".")
 
-# Reorder both heatmaps according to the tree's tip labels
-heatmap_data1 <- heatmap_data1[tree$tip.label, ]
-heatmap_data2 <- heatmap_data2[tree$tip.label, ]
+heatmap1_names <- 
+  add_prefix(row.names(heatmap_data1)) %>%
+  rename(name = ".") %>%
+  # Omit names that do not need modifying
+  dplyr::filter(!name %in% matching_names) %>%
+  left_join(tree_names)
 
-# Check if the heatmap data frames have any columns
-has_data1 <- ncol(heatmap_data1) > 0
-has_data2 <- ncol(heatmap_data2) > 0
+heatmap2_names <- 
+  add_prefix(row.names(heatmap_data2)) %>%
+  rename(name = ".") %>%
+  # Omit names that do not need modifying
+  dplyr::filter(!name %in% matching_names) %>%
+  left_join(tree_names)
 
-if (has_data1 && has_data2) {
-  # Merge the two heatmap data frames by row names
-  heatmap_data <- cbind(heatmap_data1, NA, heatmap_data2)
-  colnames(heatmap_data)[ncol(heatmap_data1) + 1] <- "Separator"
-} else if (has_data1) {
-  heatmap_data <- heatmap_data1
-} else if (has_data2) {
-  heatmap_data <- heatmap_data2
-} else {
-  # Plot only the tree with labels
-  plotTree(tree, plot=FALSE)
-  obj <- get("last_plot.phylo", envir=.PlotPhyloEnv)
-  plotTree(tree, lwd=1, ylim=c(0, obj$y.lim[2]*1.05), xlim=c(0, obj$x.lim[2]*1.1), ftype="off")
-  
-  # Retrieve the plotting details
-  obj <- get("last_plot.phylo", envir=.PlotPhyloEnv)
-  h <- max(obj$xx)
-  fsize <- 0.8
-  
-  # Add tip labels to the right of the tree without any gap
-  for (i in 1:Ntip(tree)) {
-    text(h, obj$yy[i], tree$tip.label[i], cex = fsize, pos = 4, font = 3, offset = 0)
-  }
-  
-  # Close the graphics device
-  dev.off()
-  stop("Both heatmap data files contain no gene columns. Plotting only the phylogeny tree with labels.")
-}
+# Rename files ----
+# Bit messy, sorry
+idx <- match(rownames(heatmap_data1), heatmap1_names$name)
+row.names(heatmap_data1) <- ifelse(
+  is.na(idx), 
+  row.names(heatmap_data1), 
+  heatmap1_names$tip_name[idx]
+)
 
-## Generate a combined Plot
+idx <- match(rownames(heatmap_data2), heatmap2_names$name)
+row.names(heatmap_data2) <- ifelse(
+  is.na(idx), 
+  row.names(heatmap_data2), 
+  heatmap2_names$tip_name[idx]
+)
 
-# Reorder the tree and heatmap data (already reordered above)
+# Doesn't matter if either heatmap have null results
+combined_heatmap <- cbind(heatmap_data1, heatmap_data2)
+rm(heatmap_data1, heatmap_data2, heatmap1_names, heatmap2_names, tree_names)
 
-# Plot the tree without tip labels
-plotTree(tree, plot=FALSE)
-obj <- get("last_plot.phylo", envir=.PlotPhyloEnv)
-#plotTree(tree, lwd=1, ylim=c(0, obj$y.lim[2]*1.05), xlim=c(0, obj$x.lim[2]*1.2), ftype="off")
-xlim_adjusted <- max(obj$x.lim) * 2.5  # Increase xlim to ensure space for heatmap
-ylim_adjusted <- max(obj$y.lim) * 1.3  # Increase ylim to ensure space for column labels
+# Prepare separate plots ----
+p_heat <- 
+  combined_heatmap %>%
+  rownames_to_column("Sample") %>%
+  pivot_longer(-Sample, names_to = "Gene", values_to = "Presence") %>%
+  ggplot(aes(Gene, Sample, fill = as.factor(Presence))) +
+  geom_tile(color = "white") +
+  scale_fill_manual(values = c("#D6E4F0", "#F28C8C")) +
+  scale_x_discrete(position = "top") + # display gene name
+  theme_void(base_size = 10) + # strip most theming, set font size
+  theme(
+    axis.text.x.top = element_text(angle = 55, hjust = 0, vjust = 0), # gene names positioning
+    legend.position = "none"
+  )
 
-plotTree(tree, lwd=1, ylim=c(0, ylim_adjusted), xlim=c(0, xlim_adjusted), ftype="off")
+# labels should be displayed, but the theme overwrites it. Gives the align = T
+# dots, but labels are in the next geom_text
+p_tree <- ggtree(tree, size = 1) +
+  geom_tiplab(align = T, as_ylab = T) + 
+  theme_tree2() 
 
+p_names <- tree$tip.label %>%
+  as.data.frame() %>%
+  ggplot(aes(x = 1, y = ., label = .)) +
+  geom_text(size = 5) +
+  theme_void() +
+  coord_cartesian(clip = "off")
 
-# Retrieve the plotting details
-obj <- get("last_plot.phylo", envir=.PlotPhyloEnv)
-h <- max(obj$xx)
-fsize <- 0.8
+# Generate plot ----
+# Align tree, names, and heatmap with aplot  
+main <-
+  p_heat %>% 
+  aplot::insert_left(p_names, width = 1.2) %>%
+  aplot::insert_left(p_tree, width = 0.4)
 
-# Calculate the start position for the heatmap closer to the tree
-s <- max(fsize * strwidth(tree$tip.label))
-gap <- 0.1 * s  # Define a small gap between the tree and the heatmap
-start.x <- h + gap  # Reduced space between tree and heatmap
-cols <- setNames(c("red", "blue", "white"), c(0, 1, NA))  # Red for 0, Blue for 1, White for NA
+# Set plot size dynamically
+n <- nrow(combined_heatmap)
+l <- length(tree$tip.label)
 
-# Calculate aspect ratio
-asp <- (par()$usr[2] - par()$usr[1]) / (par()$usr[4] - par()$usr[3]) * par()$pin[2] / par()$pin[1]
+WIDTH = 600 + n * 30 # tree and names = 600px + dynamic based on genes
+HEIGHT = 100 + l * 30 # dynamic padding for gene names at the top
 
-# Draw the heatmap next to the tree
-for (i in 1:ncol(heatmap_data)) {
-  if (!(has_data1 && has_data2) || i != (ncol(heatmap_data1) + 1)) {  # Skip label for separator column if both heatmaps present
-    text(start.x + (i - 1) * asp, max(obj$yy) + 1, colnames(heatmap_data)[i], pos = 4, srt = 45, cex = 0.9, offset = 0)
-  }
-  for (j in 1:nrow(heatmap_data)) {
-    xy <- c(start.x + (i - 1) * asp, obj$yy[j])
-    y <- c(xy[2] - 0.5, xy[2] + 0.5, xy[2] + 0.5, xy[2] - 0.5)
-    x <- c(xy[1] - 0.5 * asp, xy[1] - 0.5 * asp, xy[1] + 0.5 * asp, xy[1] + 0.5 * asp)
-    
-    # Adjusted endpoint for the dotted lines
-    if (i == 1) {
-      line_end_x <- start.x - 0.5 * asp
-      # Remove the dotted lines and adjust the x-coordinates to avoid gap
-      lines(c(obj$xx[j], line_end_x), rep(obj$yy[j], 2), lty = "solid", col = "gray")
-    }
-    
-    # Check for NA and set color accordingly
-    if (is.na(heatmap_data[j, i])) {
-      polygon(x, y, col = "white", border = "white")
-    } else {
-      polygon(x, y, col = cols[as.character(heatmap_data[j, i])], border = "white")
-    }
-  }
-}
-
-# Add tip labels to the right of the heatmap
-label_start_x <- start.x + ncol(heatmap_data) * asp
-for (i in 1:Ntip(tree)) {
-  text(label_start_x, obj$yy[i], tree$tip.label[i], cex = fsize, pos = 4, font = 3, offset = 0)
-}
-
-# Add labels for heatmap sections if both heatmaps are present
-if (has_data1 && has_data2) {
-  section_label_y <- -1  # Position below the heatmap
-  text(start.x + (ncol(heatmap_data1) - 1) * asp / 2, section_label_y, "AMR-genes", cex = 1.2, col = "black")
-  text(start.x + (ncol(heatmap_data1) + 1 + (ncol(heatmap_data2) - 1) * asp / 2), section_label_y, "Virulence-genes", cex = 1.2, col = "black")
-  
-  # Add colored bars for heatmap sections
-  rect(start.x - asp / 2, section_label_y - 0.5, start.x + (ncol(heatmap_data1) - 1) * asp + asp / 2, section_label_y - 0.1, col = "lightblue", border = NA)
-  rect(start.x + (ncol(heatmap_data1) + 1) * asp - asp / 2, section_label_y - 0.5, start.x + (ncol(heatmap_data1) + 1 + (ncol(heatmap_data2) - 1) * asp) + asp / 2, section_label_y - 0.1, col = "lightgreen", border = NA)
-}
-
-# Close the graphics device
+# Save to file ----
+png("combined_plot_mqc.png", width = WIDTH, height = HEIGHT)
+main
 dev.off()

--- a/main.nf
+++ b/main.nf
@@ -472,7 +472,7 @@ if ( params.help || (!params.input_directory && !params.samplesheet) || !params.
 
   // R: Plot phylogeny and heatmap
   create_phylogeny_And_Heatmap_image(
-    run_orthofinder.out.phylogeny_tree,
+    run_orthofinder.out.rooted_tree,
     generate_amrfinderplus_gene_matrix.out.amrfinderplus_gene_matrix,
     generate_abricate_gene_matrix.out.abricate_gene_matrix
   )

--- a/modules/create_phylogeny_And_Heatmap_image.nf
+++ b/modules/create_phylogeny_And_Heatmap_image.nf
@@ -1,12 +1,12 @@
 process create_phylogeny_And_Heatmap_image {
-	tag "PLOTTING PHYLOGENETIC TREE WITH AMR AND VIRULENCE GENES"
+  tag "PLOTTING PHYLOGENETIC TREE WITH AMR AND VIRULENCE GENES"
   container 'oras://community.wave.seqera.io/library/bioconductor-ggtree_r-ape_r-phytools_r-tidyverse:bd310f2405bed388'  
   publishDir "${params.outdir}/taxonomy", mode: 'copy'
   
   input:
-  path(phylogeny_tree_base_path)
+  path(rooted_tree)
   path(amrfinderplus_gene_matrix)
-	path(abricate_gene_matrix)
+  path(abricate_gene_matrix)
 
   output:
   path ("combined_plot_mqc.png"), emit: combined_plot_mqc
@@ -14,7 +14,7 @@ process create_phylogeny_And_Heatmap_image {
   script:
   """
   create_phylogeny_And_heatmap.r \\
-    ${phylogeny_tree_base_path} \\
+    ${rooted_tree} \\
     ${amrfinderplus_gene_matrix} \\
     ${abricate_gene_matrix}
   """

--- a/modules/run_orthofinder.nf
+++ b/modules/run_orthofinder.nf
@@ -2,12 +2,12 @@ process run_orthofinder{
   tag "GENERATE PHYLOGENY"
   container 'quay.io/biocontainers/orthofinder:2.5.5--hdfd78af_2'
 
-input:
+  input:
   path(phylogeny_folder)
 
   output:
-  path("phylogeny_tree"), emit: phylogeny_tree
-
+  path("phylogeny_tree"), emit: results
+  path("phylogeny_tree/Results_tree/Species_Tree/SpeciesTree_rooted.txt"), emit: rooted_tree
 
   script:
   """


### PR DESCRIPTION
## Details  

Addresses #64, specifically:
- Captures all AMR and virulence genes for each barcode
- Barcode IDs and species names displayed
- Red/blue recolour
- Dynamic plot resizing 

This PR is yet to address:
- Separating AMR and virulence gene heatmaps 

**Aligning plots**  

The `aplot` package is used to align the tree, names, and heatmap. `aplot` selected as it is already available in the process container vs. packages like `itol.toolkit` or `ggalign`.

Sample names are plotted separate to the tree for better control and to prevent it being cut off in the tree subplot.

Stitching separate subplots together also adds better plotting control and avoids using loops to add components to one big graphics device.

**Dynamic plot resizing**

The subplot and overall plot sizes will rescale based on the number of samples and genes in the heatmap.

**Nextflow output handling**

The only output of the `run_orthofinder` process used downstream is the rooted species tree - have made small changes to output the tree file directly to avoid unnecessary parsing of the orthofinder output directory.

## Testing 

Path: `/scratch/tj48/fj9712/issue-64-FAX78092`

Screenshot from the multiqc report:  

![image](https://github.com/user-attachments/assets/4a286943-4c46-4b60-b23d-06ac2c6165cd)

### Additional manual testing (local)  

![combined_plot_mqc2](https://github.com/user-attachments/assets/5d46ae1f-1e8c-4b15-846b-17139e1b9dec)

![combined_plot_mqc1](https://github.com/user-attachments/assets/1da4e335-b554-4f12-b38e-9a6c9558c78a)
