### PR TITLE
Fix: updated create_phylogenytree_related_files.py to resolve issue #70

### DIFF
--- a/bin/create_phylogenytree_related_files.py
+++ b/bin/create_phylogenytree_related_files.py
@@ -79,7 +79,7 @@ def get_available_species_genome_details_dic(assembly_summary_refseq, species_na
     species_name_noSpaces = species_name.replace(" ", "_").strip()
     species_name_for_grep = species_name.replace("_", " ").strip()
     
-    grep_species_lines = f"grep '{species_name_for_grep}' {assembly_summary_refseq} | grep 'Complete Genome' > temp_specific_species.txt"
+    grep_species_lines = f"grep '{species_name_for_grep}' {assembly_summary_refseq} | grep 'reference genome' > temp_specific_species.txt"
     os.system(grep_species_lines)
 
     input_file_name = "temp_specific_species.txt"


### PR DESCRIPTION
### Fix:
Corrected a `grep` command to use the reference genome for the species, resolving issue #70.

Fixes #70.

### Example Updated Figure:
<img width="937" alt="corrected tree" src="https://github.com/user-attachments/assets/8f30359a-bb49-4fec-bd9d-1cdd35ee7679" />