### PR TITLE
Fix QUAST reporting in MultiQC

### DIFF
--- a/modules/run_quast_qc_chromosomes.nf
+++ b/modules/run_quast_qc_chromosomes.nf
@@ -4,7 +4,7 @@ process quast_qc_chromosomes {
   publishDir "${params.outdir}/quality_control/${barcode}", mode: 'copy'
 
   input:
-  tuple val(barcode), val(assembler), path(polished_assembly, stageAs: "${barcode}_${assembler}_chr.fasta")
+  tuple val(barcode), val(assembler), path(polished_assembly)
 
   output:
   tuple val(barcode), val(assembler), path("${prefix}"), emit: results
@@ -15,6 +15,7 @@ process quast_qc_chromosomes {
   """
   quast.py \\
     --output-dir $prefix \\
+    --labels ${prefix}_chr \\
     $polished_assembly \\
     --threads $task.cpus
 

--- a/modules/run_quast_qc_chromosomes.nf
+++ b/modules/run_quast_qc_chromosomes.nf
@@ -4,7 +4,7 @@ process quast_qc_chromosomes {
   publishDir "${params.outdir}/quality_control/${barcode}", mode: 'copy'
 
   input:
-  tuple val(barcode), val(assembler), path(polished_assembly)
+  tuple val(barcode), val(assembler), path(polished_assembly, stageAs: "${barcode}_${assembler}_chr.fasta")
 
   output:
   tuple val(barcode), val(assembler), path("${prefix}"), emit: results


### PR DESCRIPTION
This addresses the issue described in #80 where QUAST statistics were overwriting each other in the MultiQC report due to having the same assembly name. The specific fix for QUAST was to simply use the `--labels` parameter to give the assembly a custom name. I have used `<sample>_<assembler>_chr` as the label so that it matches the label given by Bakta. That way, the QUAST and the Bakta summary results get added to the same rows in the general stats table. This not only makes the table more concise, but also lets you see at a glance which assembly has been picked as the 'best', since Bakta is only run on the 'best' assembly.