### PR TITLE
Split MultiQC and add Autocycler metrics

### DIFF
--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -127,6 +127,8 @@ report_section_order:
         order: -9950 
     busco:
         order: -9970
+    autocycler_metrics:
+        order: -9980
     bandage:
         order: -9990
     multiqc_software_versions:

--- a/assets/multiqc_results_config.yml
+++ b/assets/multiqc_results_config.yml
@@ -26,8 +26,8 @@ report_header_info:
 fn_clean_exts:
   - ".gz"
   - ".txt"
+  - ".k2report"
   - "_allfiles-cat_nr.fastq"
-  - "_busco"
 
 fn_clean_trim:
   - "short_summary.specific.bacteria_odb10."
@@ -35,47 +35,38 @@ fn_clean_trim:
 # Hide unnecessary columns in the report
 # Columns that are not relevant to the end user are hidden for clarity.
 table_columns_visible:
-  NanoStat:
-    Active channels_seq summary: False
+  "kraken2: taxonomic classification":
+    pct_top_one: False
+    pct_top_n: False
+    pct_unclassified: False
+    
+  "bakta: Bacterial annotation pipeline":
+    Length: False
 
 # Define custom placement of columns in tables
 # Columns are reordered to prioritise the most important information for easy interpretation.
 table_columns_placement:
   table-general_stats_table:
-    "Total length": 900
-    N50: 1010
+    Count: 1020
+    CDSs: 1030
 
 # Rename columns for clarity
 # Column names are modified to be more descriptive and understandable.
 table_columns_name:
-    QUAST:
-      N50: "N50 contig length"
-
-# Adjust QUAST display units
-# QUAST (Quality Assessment Tool for genome assemblies) output is adjusted for readability by using megabase pairs (Mbp).
-quast_config:
-  contig_length_multiplier: 0.000001
-  contig_length_suffix: "Mbp"
-  total_length_multiplier: 0.000001
-  total_length_suffix: "Mbp"
-  total_number_contigs_multiplier: 1
-  total_number_contigs_suffix: ""
+  Bakta:
+    Count: "Number of contigs in assembly"
+    CDSs: "Number of Coding sequences (CDS)"
 
 # Customise module descriptions for clarity
 # Detailed descriptions are provided to explain the purpose and relevance of each analysis tool to a non-expert audience.
 
-# NanoStat: Summarizes sequencing run quality
-nanostat:
-  name: "NanoStat: Summary of the Sequencing Run"
-  description: "NanoStat provides an overview of the quality of the ONT sequencing run, including metrics such as read length and quality scores. This helps to assess the overall success of the sequencing process before moving on to more detailed analyses."
-
 custom_data:
   images:
-    title: "PycoQC: Summary of the Sequencing Run"
-    section_name: "pycoQC_mqc_html"
-    section_anchor: "pycoQC_mqc_html"
-    description: "PycoQC visualises the quality control metrics of ONT sequencing runs. These plots help in identifying potential issues with sequencing, such as bias in read lengths or poor base calling quality."
-    image_file: "pycoQC_mqc.html"
+    title: "Phylogenetic Tree and Heatmap: Genetic Relationships and AMR/Virulence Gene Detection"
+    section_name: "combined_plot_mqc_png"
+    section_anchor: "combined_plot_mqc_png"
+    description: "This heatmap visualises the evolutionary relationships between the samples, showing how closely related they are based on genetic data. Additionally, it provides a heatmap of known virulence and AMR genes identified in the samples."
+    image_file: "combined_plot_mqc.png"
 
   species_stats:
     extra_data:
@@ -101,11 +92,9 @@ fn_ignore_dirs:
   - "results/*/bakta/unicyclerChromosomes"
   - "results/*/bakta/flyeChromosomes"
   - "results/*/bakta/prePolished_ChrContigs"
-  - "results/*/quast_QC"
   - "results/*/bakta/unicyclerChromosomes/BUSCO"
   - "results/*/bakta/flyeChromosomes/BUSCO"
   - "results/*/bakta/prePolished_ChrContigs/BUSCO"
-  - "results/*/quast_QC"
   - "results/*/assemblies/plassembler"
   - "results/*/assemblies/Flye_assembly/NonChr_contigs"
   - "results/*/assemblies/unicycler_assembly/NonChr_contigs"
@@ -117,26 +106,23 @@ report_section_order:
         order: -9880
     sampleID_species_table_mqc:
         order: -9900
-    nanostat:
-        order: -9910
-    pycoQC_mqc_html:
-        order: -9920
-    porechop:
-        order: -9930
-    quast:
-        order: -9950 
-    busco:
-        order: -9970
-    bandage:
-        order: -9990
+    kraken:
+        order: -9940
+    bakta:
+        order: -9960 
+    combined_plot_mqc_png:
+        order: -9980
     multiqc_software_versions:
         order: -10000
+
+remove_sections:
+  - kraken-duplication-topfive
 
 # List software versions
 # The versions of the software used in the analysis are listed for reproducibility and reference.
 software_versions:
-  busco: "5.6.1"
-  porechop: "0.2.4"
+  bakta: "1.9.2"
+  kraken2: "2.1.3"
   multiqc: "1.20"
 
 # Tidy up various things in the report

--- a/bin/generate_autocycler_metrics_mqc.py
+++ b/bin/generate_autocycler_metrics_mqc.py
@@ -1,0 +1,67 @@
+#!/usr/bin/env python3
+import pandas as pd
+import argparse
+import os
+
+def main(args):
+    metrics = pd.read_table(args.input, sep='\t', index_col='name')
+
+    list_columns = [
+        'untrimmed_cluster_size',
+        'untrimmed_cluster_distance',
+        'trimmed_cluster_size',
+        'trimmed_cluster_median',
+        'trimmed_cluster_mad',
+    ]
+
+    metrics_lists = metrics[list_columns].apply(
+        lambda x: x.str.replace('[', '').str.replace(']', '').str.split(',')
+    )
+    metrics_lists['cluster'] = metrics_lists.apply(
+        lambda x: [f'cluster_{i + 1}' for i in range(0, len(x.untrimmed_cluster_size))],
+        axis=1
+    )
+    metrics_lists = metrics_lists.explode(list_columns + ['cluster'])
+    metrics_lists['name'] = metrics_lists.index + '_' + metrics_lists['cluster']
+    metrics_lists = metrics_lists.set_index('name')
+    metrics_lists.drop(columns=['cluster'], inplace=True)
+
+    non_list_columns = [c for c in metrics.columns if c not in list_columns]
+    metrics = pd.concat([metrics[non_list_columns], metrics_lists]).sort_index()
+
+    headers = '\n'.join([
+        '# id: autocycler_metrics',
+        '# section_name: "Autocycler Metrics"',
+        '# description: "A summary of Autocycler\'s output metrics."',
+        '# format: "tsv"',
+        '# plot_type: "table"',
+        '# pconfig:',
+        '#     id: "autocycler_metrics_table"',
+    ]) + '\n'
+
+    output = headers + metrics.to_csv(sep='\t')
+
+    with open(args.output, 'w') as f:
+        f.write(output)
+
+
+def get_args():
+    parser = argparse.ArgumentParser(description="Prepare Autocycler metrics table for use in a MultiQC report.")
+    
+    # Add arguments
+    parser.add_argument('-i', '--input', type=str, required=True, help='Path to the Autocycler metrics TSV file.')
+    parser.add_argument('-o', '--output', type=str, required=True, help='Path to the output MultiQC-ready TSV file.')
+    
+    # Parse arguments
+    args = parser.parse_args()
+
+    # Check inputs
+    assert isinstance(args.input, str) and os.path.isfile(args.input), 'Error: Invalid input file.'
+    assert isinstance(args.output, str) and not os.path.exists(args.output), 'Error: Invalid output file.'
+
+    return args
+
+
+if __name__ == '__main__':
+    args = get_args()
+    main(args)

--- a/bin/generate_autocycler_metrics_mqc.py
+++ b/bin/generate_autocycler_metrics_mqc.py
@@ -4,7 +4,10 @@ import argparse
 import os
 
 def main(args):
-    metrics = pd.read_table(args.input, sep='\t', index_col='name')
+    metrics = pd.concat([
+        pd.read_table(f, sep='\t', index_col='name')
+        for f in args.input
+    ])
 
     list_columns = [
         'untrimmed_cluster_size',
@@ -49,15 +52,15 @@ def get_args():
     parser = argparse.ArgumentParser(description="Prepare Autocycler metrics table for use in a MultiQC report.")
     
     # Add arguments
-    parser.add_argument('-i', '--input', type=str, required=True, help='Path to the Autocycler metrics TSV file.')
     parser.add_argument('-o', '--output', type=str, required=True, help='Path to the output MultiQC-ready TSV file.')
+    parser.add_argument('input', type=str, nargs='+', help='Path to one or more Autocycler metrics TSV files.')
     
     # Parse arguments
     args = parser.parse_args()
 
     # Check inputs
-    assert isinstance(args.input, str) and os.path.isfile(args.input), 'Error: Invalid input file.'
     assert isinstance(args.output, str) and not os.path.exists(args.output), 'Error: Invalid output file.'
+    assert isinstance(args.input, list) and all([isinstance(f, str) for f in args.input]) and all([os.path.isfile(f) for f in args.input]), 'Error: Invalid input file(s).'
 
     return args
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -143,7 +143,7 @@ The output directory will contain the following sub-directories:
 - `quality_control`: Quality information assessed by QUAST, BUSCO, Kraken2, PycoQC, and NanoPlot.
 - `annotations`: Annotations for antimicrobial resistance genes, virulence genes, plasmid annotations, and bacterial genome annotations.
 - `taxonomy`: Phylogenetic tree information.
-- `report`: A final MultiQC report summarising the pipeline run.
+- `report`: MultiQC reports summarising the pipeline run.
 
 For detailed information about interpreting the pipeline results, see [docs/interpreting-results.md](docs/interpreting-results.md)
 

--- a/docs/interpreting-results.md
+++ b/docs/interpreting-results.md
@@ -114,7 +114,11 @@ Bakta has been used to annotate the plasmid assemblies in this pipeline. Bakta a
 
 ### `report/` 
 
-This pipeline has used MultiQC to aggregate stats and summaries for various steps of the pipeline. The pipeline will output the MultiQC report as `${params.outdir}/report/multiqc_report.html`. The report can be opened in a web browser and contains a summary of the pipeline run, including the command line parameters used, the pipeline version, and the run time. 
+This pipeline uses MultiQC to aggregate stats and summaries for various steps of the pipeline. The pipeline will output two MultiQC reports, both of which can be opened in a web browser.
+
+The first report summarises the sequencing and assembly quality control metrics, and will be located at `${params.outdir}/report/multiqc_report.html`. It includes data from PycoQC and NanoStat about the sequencing run, as well as QUAST and BUSCO metrics for each of the assemblies and (if used) metrics specific to Autocycler's consensus assembly.
+
+The second report summarises the results of the pipeline, including the results from Kraken and Bakta, and the phylogenetic tree and AMR/virulence gene findings.
 
 ### `taxonomy/`
 

--- a/docs/interpreting-results.md
+++ b/docs/interpreting-results.md
@@ -118,7 +118,7 @@ This pipeline uses MultiQC to aggregate stats and summaries for various steps of
 
 The first report summarises the sequencing and assembly quality control metrics, and will be located at `${params.outdir}/report/multiqc_report.html`. It includes data from PycoQC and NanoStat about the sequencing run, as well as QUAST and BUSCO metrics for each of the assemblies and (if used) metrics specific to Autocycler's consensus assembly.
 
-The second report summarises the results of the pipeline, including the results from Kraken and Bakta, and the phylogenetic tree and AMR/virulence gene findings.
+The second report summarises the results of the pipeline, including the results from Kraken and Bakta, and the phylogenetic tree and AMR/virulence gene findings. This will be loacted at `${params.outdir}/report/results/multiqc_report.html`.
 
 ### `taxonomy/`
 

--- a/main.nf
+++ b/main.nf
@@ -234,6 +234,7 @@ workflow {
 
     polished_consensus_per_barcode = trycycler.out.polished_consensus_per_barcode
     consensus_gfa_per_barcode = Channel.empty()  // To ensure that consensus_gfa_per_barcode exists
+    autocycler_metrics = Channel.empty()  // To ensure that autocycler_metrics exists
   } else if (params.consensus_method == 'autocycler') {
     // RUN AUTOCYCLER
 
@@ -247,6 +248,7 @@ workflow {
 
     polished_consensus_per_barcode = autocycler.out.polished_consensus_per_barcode
     consensus_gfa_per_barcode = autocycler.out.consensus_gfa_per_barcode
+    autocycler_metrics = autocycler.out.metrics
   } else {
     error 'Invalid value for `consensus_method`: ' + params.consensus_method
   }
@@ -443,6 +445,9 @@ workflow {
 
   bandage_report = generate_bandage_report.out.bandage_report
 
+  autocycler_metrics_for_mqc = autocycler_metrics
+    .ifEmpty([])
+
   multiqc_config = params.multiqc_config
   multiqc_results_config = params.multiqc_results_config
 
@@ -454,7 +459,8 @@ workflow {
     multiqc_config,
     quast_required_for_multiqc,
     busco_required_for_multiqc,
-    bandage_report
+    bandage_report,
+    autocycler_metrics_for_mqc
   )
   // Results report
   multiqc_results_report(

--- a/main.nf
+++ b/main.nf
@@ -42,6 +42,7 @@ include { generate_amrfinderplus_gene_matrix } from './modules/generate_amrfinde
 include { generate_abricate_gene_matrix } from './modules/generate_abricate_gene_matrix'
 include { create_phylogeny_And_Heatmap_image } from './modules/create_phylogeny_And_Heatmap_image'
 include { multiqc_report } from './modules/run_multiqc'
+include { multiqc_results_report } from './modules/run_multiqc_results'
 
 // Print a header for your pipeline 
 log.info """\
@@ -443,19 +444,25 @@ workflow {
   bandage_report = generate_bandage_report.out.bandage_report
 
   multiqc_config = params.multiqc_config
+  multiqc_results_config = params.multiqc_results_config
 
   // Run MultiQC with the gathered inputs
+  // QC report
   multiqc_report(
     pycoqc_required_for_multiqc,
     nanoplot_required_for_multiqc,
     multiqc_config,
-    kraken2_required_for_multiqc,
     quast_required_for_multiqc,
+    busco_required_for_multiqc,
+    bandage_report
+  )
+  // Results report
+  multiqc_results_report(
+    multiqc_results_config,
+    kraken2_required_for_multiqc,
     bakta_required_for_multiqc,
     bakta_plasmids_required_for_multiqc,
-    busco_required_for_multiqc,
-    phylogeny_heatmap_plot_required_for_multiqc,
-    bandage_report
+    phylogeny_heatmap_plot_required_for_multiqc
   )
 }
 

--- a/modules/run_autocycler_table.nf
+++ b/modules/run_autocycler_table.nf
@@ -7,14 +7,14 @@ process autocycler_table {
   tuple val(barcode), path(autocycler_dir)
 
   output:
-  tuple val(barcode), path("metrics.tsv"), emit: metrics
+  tuple val(barcode), path("${barcode}_metrics.tsv"), emit: metrics
 
   script:
   """
-  autocycler table > metrics.tsv  # Header row
+  autocycler table > ${barcode}_metrics.tsv  # Header row
   autocycler table \\
     --autocycler_dir autocycler_out \\
     --name ${barcode} \\
-    >> metrics.tsv
+    >> ${barcode}_metrics.tsv
   """
 }

--- a/modules/run_autocycler_table_mqc.nf
+++ b/modules/run_autocycler_table_mqc.nf
@@ -4,10 +4,10 @@ process autocycler_table_mqc {
   publishDir "${params.outdir}/report/autocycler", mode: 'copy'
 
   input:
-  tuple path(metrics_tsvs)
+  path(metrics_tsvs)
 
   output:
-  tuple path("autocycler_mqc.tsv"), emit: metrics
+  path("autocycler_mqc.tsv"), emit: metrics
 
   script:
   """

--- a/modules/run_autocycler_table_mqc.nf
+++ b/modules/run_autocycler_table_mqc.nf
@@ -4,13 +4,13 @@ process autocycler_table_mqc {
   publishDir "${params.outdir}/report/autocycler", mode: 'copy'
 
   input:
-  tuple val(barcode), path(metrics_tsv)
+  tuple path(metrics_tsvs)
 
   output:
-  tuple val(barcode), path("autocycler_mqc.tsv"), emit: metrics
+  tuple path("autocycler_mqc.tsv"), emit: metrics
 
   script:
   """
-  generate_autocycler_metrics_mqc.py -i ${metrics_tsv} -o autocycler_mqc.tsv
+  generate_autocycler_metrics_mqc.py -o autocycler_mqc.tsv ${metrics_tsvs}
   """
 }

--- a/modules/run_autocycler_table_mqc.nf
+++ b/modules/run_autocycler_table_mqc.nf
@@ -1,0 +1,16 @@
+process autocycler_table_mqc {
+  tag "AUTOCYCLER TABLE MQC PREP: ${barcode}"
+  container 'quay.io/biocontainers/pandas:2.2.1'
+  publishDir "${params.outdir}/report/autocycler", mode: 'copy'
+
+  input:
+  tuple val(barcode), path(metrics_tsv)
+
+  output:
+  tuple val(barcode), path("autocycler_mqc.tsv"), emit: metrics
+
+  script:
+  """
+  generate_autocycler_metrics_mqc.py -i ${metrics_tsv} -o autocycler_mqc.tsv
+  """
+}

--- a/modules/run_multiqc.nf
+++ b/modules/run_multiqc.nf
@@ -7,12 +7,8 @@ process multiqc_report {
   path(pycoqc)
   path(nanoplot)
   path(multiqc_config)
-  path(kraken2)
   path(quast)
-  path(bakta)
-  path(bakta_plasmids)
   path(busco)
-  path(phylogeny_heatmap_plot)
   path(bandage_report)
 
   output:

--- a/modules/run_multiqc.nf
+++ b/modules/run_multiqc.nf
@@ -10,6 +10,7 @@ process multiqc_report {
   path(quast)
   path(busco)
   path(bandage_report)
+  path(autocycler_metrics)
 
   output:
   path ("*"), emit: multiqc

--- a/modules/run_multiqc_results.nf
+++ b/modules/run_multiqc_results.nf
@@ -1,7 +1,7 @@
 process multiqc_results_report {
   tag "GENERATING RESULTS SUMMARY REPORT"
   container 'quay.io/biocontainers/multiqc:1.21--pyhdfd78af_0'
-  publishDir "${params.outdir}/report", mode: 'copy'
+  publishDir "${params.outdir}/report/results", mode: 'copy'
 
   input:
   path(multiqc_results_config)

--- a/modules/run_multiqc_results.nf
+++ b/modules/run_multiqc_results.nf
@@ -1,0 +1,23 @@
+process multiqc_results_report {
+  tag "GENERATING RESULTS SUMMARY REPORT"
+  container 'quay.io/biocontainers/multiqc:1.21--pyhdfd78af_0'
+  publishDir "${params.outdir}/report", mode: 'copy'
+
+  input:
+  path(multiqc_results_config)
+  path(kraken2)
+  path(bakta)
+  path(bakta_plasmids)
+  path(phylogeny_heatmap_plot)
+
+  output:
+  path ("*"), emit: multiqc
+
+  script:
+  """
+  multiqc -c ${params.multiqc_results_config} .	
+  """
+
+}
+
+

--- a/nextflow.config
+++ b/nextflow.config
@@ -48,6 +48,7 @@ params {
 	consensus_method = 'autocycler'  // alt: 'trycycler'
 	subsamples = 4  // Set to 0 with trycycler to skip subsampling
   multiqc_config = "${projectDir}/assets/multiqc_config.yml"
+  multiqc_results_config = "${projectDir}/assets/multiqc_results_config.yml"
   bandage_templates = "${projectDir}/assets/bandage_templates"
   sequencing_summary = '' 
   pycoqc_header_file = "${projectDir}/assets/pycoqc_report_header.txt"

--- a/subworkflows/autocycler.nf
+++ b/subworkflows/autocycler.nf
@@ -14,6 +14,7 @@ include { autocycler_trim } from '../modules/run_autocycler_trim'
 include { autocycler_resolve } from '../modules/run_autocycler_resolve'
 include { autocycler_combine } from '../modules/run_autocycler_combine'
 include { autocycler_table } from '../modules/run_autocycler_table'
+include { autocycler_table_mqc } from '../modules/run_autocycler_table_mqc'
 
 
 workflow autocycler {
@@ -69,6 +70,8 @@ workflow autocycler {
 
     autocycler_table(autocycler_combine.out.autocycler_out)
 
+    autocycler_table_mqc(autocycler_table.out.metrics)
+
     consensus =
         autocycler_combine.out.autocycler_out
         .map { barcode, autocycler_dir ->
@@ -88,4 +91,5 @@ workflow autocycler {
     emit:
     polished_consensus_per_barcode = consensus
     consensus_gfa_per_barcode = consensus_gfa
+    metrics = autocycler_table_mqc.out.metrics
 }

--- a/subworkflows/autocycler.nf
+++ b/subworkflows/autocycler.nf
@@ -70,7 +70,11 @@ workflow autocycler {
 
     autocycler_table(autocycler_combine.out.autocycler_out)
 
-    autocycler_table_mqc(autocycler_table.out.metrics)
+    all_autocycler_metrics = autocycler_table.out.metrics
+        .map { barcode, tsv -> tsv }
+        .collect()
+
+    autocycler_table_mqc(all_autocycler_metrics)
 
     consensus =
         autocycler_combine.out.autocycler_out


### PR DESCRIPTION
This addresses two issues:

- #79 - splitting the MultiQC report into a sequencing/assembly QC report and a results report
- #78 - adding the `autocycler table` metrics table to the assembly QC report

The sequencing/assembly QC report contains:

- pycoQC
- NanoStat
- QUAST
- BUSCO
- Autocycler metrics
- Bandage plots

The results report contains:

- Kraken
- Bakta
- Phylogenetic tree + AMR heatmap

You can find examples of the reports on [SharePoint](https://unisyd.sharepoint.com/teams/SydneyInformaticsHub2/Shared%20Documents/Forms/AllItems.aspx?id=%2Fteams%2FSydneyInformaticsHub2%2FShared%20Documents%2F1%20SIH%20Central%20Document%20Repository%2FProjects%2F1%20JIRA%20projects%2FPIPE%2D4747%20Francisca%20Samsing%20%2D%20Genomics%20in%20a%20backpack%2FResults%2F2506%5Fsplit%5Fmultiqc&viewid=0a2a83b7%2D13a7%2D412d%2D9f50%2Df9174718726a&csf=1&web=1&e=IZ7kW9&CID=9a043186%2D35f7%2D40d3%2D85ad%2D0b81d4027b57&FolderCTID=0x01200036946701AA9B66498938268891B63695):

- Original report (all in one): multiqc_report.original.html
- New QC report: multiqc_report.split.qc.html
- New results report: multiqc_report.split.results.html