### PR TITLE
Fix AMR heatmap colour scale

### DIFF
--- a/bin/create_phylogeny_And_heatmap.r
+++ b/bin/create_phylogeny_And_heatmap.r
@@ -98,7 +98,7 @@ p_heat <-
   pivot_longer(-Sample, names_to = "Gene", values_to = "Presence") %>%
   ggplot(aes(Gene, Sample, fill = as.factor(Presence))) +
   geom_tile(color = "white") +
-  scale_fill_manual(values = c("#D6E4F0", "#F28C8C")) +
+  scale_fill_manual(values = c("#D6E4F0", "#F28C8C"), breaks = c(0, 1)) +  # matrix will only ever have 0 and 1 values, always set 0 to grey blue, 1 to red
   scale_x_discrete(position = "top") + # display gene name
   theme_void(base_size = 10) + # strip most theming, set font size
   theme(


### PR DESCRIPTION
This is a single line change to fix how the heatmap colour scale works.

The input data to the heatmap is just a matrix of 0s and 1s (0 = absence of gene, 1 = presence).

The colour scale for the heatmap was already set to grey-blue for the low values and red for the high values. However, the breaks weren't set, so the colours would auto-scale. A matrix of all 0s and a matrix of all 1s would look identical, using the grey-blue colour. For a matrix of all 1s, this could give the impression that there were no AMR/virulence genes detected, when in fact all the genes listed were present.

This update adds the `breaks = c(0, 1)` argument, so now grey-blue will always represent 0 and red will always represent 1.