### PR TITLE
Allow autocycler to fail safely

### DIFF
--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -116,7 +116,7 @@ report_section_order:
     general_stats:
         order: -9880
     failure_warnings:
-        order: -9850
+        order: -9890
     sampleID_species_table_mqc:
         order: -9900
     nanostat:

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -115,6 +115,8 @@ fn_ignore_dirs:
 report_section_order:
     general_stats:
         order: -9880
+    failure_warnings:
+        order: -9850
     sampleID_species_table_mqc:
         order: -9900
     nanostat:

--- a/assets/multiqc_config.yml
+++ b/assets/multiqc_config.yml
@@ -115,7 +115,7 @@ fn_ignore_dirs:
 report_section_order:
     general_stats:
         order: -9880
-    failure_warnings:
+    Consensus Assembly Failure Warnings:
         order: -9890
     sampleID_species_table_mqc:
         order: -9900

--- a/assets/multiqc_results_config.yml
+++ b/assets/multiqc_results_config.yml
@@ -104,6 +104,8 @@ fn_ignore_dirs:
 report_section_order:
     general_stats:
         order: -9880
+    failure_warnings:
+        order: -9850
     sampleID_species_table_mqc:
         order: -9900
     kraken:

--- a/assets/multiqc_results_config.yml
+++ b/assets/multiqc_results_config.yml
@@ -104,7 +104,7 @@ fn_ignore_dirs:
 report_section_order:
     general_stats:
         order: -9880
-    failure_warnings:
+    Consensus Assembly Failure Warnings:
         order: -9890
     sampleID_species_table_mqc:
         order: -9900

--- a/assets/multiqc_results_config.yml
+++ b/assets/multiqc_results_config.yml
@@ -105,7 +105,7 @@ report_section_order:
     general_stats:
         order: -9880
     failure_warnings:
-        order: -9850
+        order: -9890
     sampleID_species_table_mqc:
         order: -9900
     kraken:

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -111,6 +111,18 @@ nextflow run main.nf --subsamples 8 [...]
 
 For Trycycler, you can disable subsampling altogether by using `--subsamples 1`. Subsampling is required for the Autocycler implementation and cannot be turned off.
 
+#### Consensus assembly failures
+
+In some cases, such as samples with low coverage or high fragmentation, the consensus assembly method may fail. In these cases, the pipeline will fall back to using one of the de novo assembly methods (currently either Unicycler or Flye). If this occurs, a message will be printed to the terminal and/or standard output where the pipeline is running, and a table of failed samples will appear at the top of the MultiQC reports.
+
+When generating a consensus sequence with autocycler, one of the causes of such a failure is if the mean number of contigs per assembly exceeds a set value. This threshold is `25` by default, but can be changed by providing the `--max_contigs` parameter when running Nextflow:
+
+```bash
+nextflow run main --max_contigs 50 [...]
+```
+
+Note that this may fix the issue in some cases, but for highly fragmented assemblies, autocycler may still fail to generate a consensus sequence.
+
 ### Putting it together
 
 A typical run might look like the following. Assuming a run on gadi, with a pre-downloaded Kraken2 database at `/scratch/ab01/kraken_db`, a samplesheet at `/scratch/ab01/samplesheet.csv`, a sequencing summary file at `/scratch/ab01/dataset/sequencing_summary.txt`, and high-accuracy basecalling, we would do the following:

--- a/main.nf
+++ b/main.nf
@@ -256,13 +256,15 @@ workflow {
 
   // Identify failed barcodes and create a list of their names
   consensus_successes = polished_consensus_per_barcode
-    .ifEmpty([null, null, true])  // Gives us something to join against, will be filtered out below
+    .ifEmpty([null, null, null])  // Gives us something to join against, will be filtered out below
   consensus_failures = concat_fastqs.out.concat_fq
     .map { barcode, _fq -> barcode }
     .unique()
     .join(consensus_successes, remainder: true)
-    .filter { _barcode, _assembler, fa -> !fa }
-    .map { barcode, _assembler, _fa -> barcode }
+    .filter { x ->
+      x.size() == 2 && !x[1]
+    }
+    .map { barcode, _nullval -> barcode }
     .collect()
 
   // Generate MultiQC-ready YAML file of failed barcodes

--- a/main.nf
+++ b/main.nf
@@ -487,33 +487,36 @@ workflow {
     phylogeny_heatmap_plot_required_for_multiqc,
     consensus_warnings
   )
+  // Print workflow execution summary 
+  workflow.onComplete = {
+    def summary = """
+    =======================================================================================
+    Workflow execution summary
+    =======================================================================================
+
+    Duration    : ${workflow.duration}
+    Success     : ${workflow.success}
+    workDir     : ${workflow.workDir}
+    Exit status : ${workflow.exitStatus}
+    results     : ${params.outdir}
+
+    =======================================================================================
+    """
+    println summary.replaceAll(/(^|\n)\s+/, '\n')
+
+    // If there were failed consensus assemblies, print a warning message
+    def consensus_failure_strings = consensus_failures.value
+    if (consensus_failure_strings.size() > 0) {
+      def msg = """
+      ===== CONSENSUS ASSEMBLY FAILURES =====
+      WARNING: Consensus assembly failed for
+      the following samples:
+      ${consensus_failure_strings.join('\n')}
+      =======================================
+      """
+      println msg.replaceAll(/(^|\n)\s+/, '\n')
+    }
+
+  }
 }
 
-// Print workflow execution summary 
-workflow.onComplete {
-summary = """
-=======================================================================================
-Workflow execution summary
-=======================================================================================
-
-Duration    : ${workflow.duration}
-Success     : ${workflow.success}
-workDir     : ${workflow.workDir}
-Exit status : ${workflow.exitStatus}
-results     : ${params.outdir}
-
-=======================================================================================
-  """
-println summary
-
-// If there were failed consensus assemblies, print a warning message
-consensus_failure_strings = consensus_failures.value
-if (consensus_failure_strings.size() > 0) {
-  println "===== CONSENSUS ASSEMBLY FAILURES ====="
-  println "WARNING: Consensus assembly failed for"
-  println "the following samples:"
-  println consensus_failure_strings.join('\n')
-  println "======================================="
-}
-
-}

--- a/main.nf
+++ b/main.nf
@@ -515,7 +515,12 @@ workflow {
       ===== CONSENSUS ASSEMBLY FAILURES =====
       WARNING: Consensus assembly failed for
       the following samples:
+
       ${consensus_failure_strings.join('\n')}
+
+      For each of these samples, one of the
+      de novo assemblies was chosen for
+      downstream analyses
       =======================================
       """
       println msg.replaceAll(/(^|\n)\s+/, '\n')

--- a/modules/generate_consensus_warnings.nf
+++ b/modules/generate_consensus_warnings.nf
@@ -12,8 +12,8 @@ process generate_consensus_warnings {
   script:
   yaml_data = [
     'id: "failure_warnings"',
-    'section_name: "Failure Warnings"',
-    'description: "The following samples failed consensus assembly."',
+    'section_name: "Consensus Assembly Failure Warnings"',
+    'description: "The following samples failed consensus assembly. For each of these samples, one of the de novo assemblies was chosen for downstream analyses."',
     'plot_type: "table"',
     'headers:',
     '  consensus_method:',

--- a/modules/generate_consensus_warnings.nf
+++ b/modules/generate_consensus_warnings.nf
@@ -1,0 +1,30 @@
+process generate_consensus_warnings {
+  tag "GENERATE WARNINGS FOR CONSENSUS SEQUENCE FAILURES"
+  // No container because this runs basic bash code
+
+  input:
+  val failed_barcodes
+  val consensus_method
+
+  output:
+  path 'failed_consensus_mqc.yaml', emit: mqc_yaml
+
+  script:
+  yaml_data = [
+    'id: "failure_warnings"',
+    'section_name: "Failure Warnings"',
+    'description: "The following samples failed consensus assembly."',
+    'plot_type: "table"',
+    'headers:',
+    '  consensus_method:',
+    '    title: "Consensus Assembly Method"',
+    '  consensus_status:',
+    '    title: "Status"',
+    'data:'
+  ]
+  yaml_data += failed_barcodes.collect { x -> "  ${x}:\n    consensus_method: '${consensus_method}'\n    consensus_status: 'Fail'" }
+  yaml_data = yaml_data.join('\n')
+  """
+  echo -e '${yaml_data}' > failed_consensus_mqc.yaml
+  """
+}

--- a/modules/run_autocycler_cluster.nf
+++ b/modules/run_autocycler_cluster.nf
@@ -1,6 +1,7 @@
 process autocycler_cluster {
   tag "AUTOCYCLER CLUSTER: ${barcode}"
   container 'quay.io/biocontainers/autocycler:0.3.0--h3ab6199_0'
+  errorStrategy { task.exitStatus == 1 ? 'ignore' : 'finish' }
 
   input:
   tuple val(barcode), path(autocycler_dir)

--- a/modules/run_autocycler_cluster.nf
+++ b/modules/run_autocycler_cluster.nf
@@ -10,10 +10,12 @@ process autocycler_cluster {
   tuple val(barcode), path("autocycler_cluster_out/clustering/qc_pass/cluster_*"), emit: pass_clusters
 
   script:
+  max_contigs_param = params.max_contigs && params.max_contigs.toString().isInteger() ? "--max_contigs ${params.max_contigs}" : ""
   """
   cp -rL ${autocycler_dir} autocycler_cluster_out 
 
   autocycler cluster \\
-    --autocycler_dir autocycler_cluster_out
+    --autocycler_dir autocycler_cluster_out \\
+    ${max_contigs_param}
   """
 }

--- a/modules/run_autocycler_compress.nf
+++ b/modules/run_autocycler_compress.nf
@@ -3,7 +3,7 @@ process autocycler_compress {
   container 'quay.io/biocontainers/autocycler:0.3.0--h3ab6199_0'
   // Autocycler compress can fail if the assembly is too fragmented
   // We can allow this and fall back to using the de novo assemblers
-  errorStrategy { task.exitStatus == 1 ? 'ignore' : 'finish' }
+  errorStrategy { task.exitStatus == 1 && params.fallback_denovo ? 'ignore' : 'finish' }
 
   input:
   tuple val(barcode), path(assembly_fastas)
@@ -12,6 +12,7 @@ process autocycler_compress {
   tuple val(barcode), path("autocycler_compress_out"), emit: compressed
 
   script:
+  max_contigs_param = params.max_contigs && params.max_contigs.toString().isInteger() ? "--max_contigs ${params.max_contigs}" : ""
   """
   mkdir assemblies
   for d in ${assembly_fastas}
@@ -22,6 +23,7 @@ process autocycler_compress {
   autocycler compress \\
     --assemblies_dir assemblies \\
     --autocycler_dir autocycler_compress_out \\
+    ${max_contigs_param} \\
     --threads ${task.cpus}
   """
 }

--- a/modules/run_autocycler_compress.nf
+++ b/modules/run_autocycler_compress.nf
@@ -3,7 +3,7 @@ process autocycler_compress {
   container 'quay.io/biocontainers/autocycler:0.3.0--h3ab6199_0'
   // Autocycler compress can fail if the assembly is too fragmented
   // We can allow this and fall back to using the de novo assemblers
-  errorStrategy { task.exitStatus == 1 && params.fallback_denovo ? 'ignore' : 'finish' }
+  errorStrategy { task.exitStatus == 1 ? 'ignore' : 'finish' }
 
   input:
   tuple val(barcode), path(assembly_fastas)

--- a/modules/run_autocycler_compress.nf
+++ b/modules/run_autocycler_compress.nf
@@ -1,6 +1,9 @@
 process autocycler_compress {
   tag "AUTOCYCLER COMPRESS: ${barcode}"
   container 'quay.io/biocontainers/autocycler:0.3.0--h3ab6199_0'
+  // Autocycler compress can fail if the assembly is too fragmented
+  // We can allow this and fall back to using the de novo assemblers
+  errorStrategy { task.exitStatus == 1 ? 'ignore' : 'finish' }
 
   input:
   tuple val(barcode), path(assembly_fastas)

--- a/modules/run_multiqc.nf
+++ b/modules/run_multiqc.nf
@@ -11,6 +11,7 @@ process multiqc_report {
   path(busco)
   path(bandage_report)
   path(autocycler_metrics)
+  path(consensus_warning_yaml)
 
   output:
   path ("*"), emit: multiqc

--- a/modules/run_multiqc_results.nf
+++ b/modules/run_multiqc_results.nf
@@ -9,6 +9,7 @@ process multiqc_results_report {
   path(bakta)
   path(bakta_plasmids)
   path(phylogeny_heatmap_plot)
+  path(consensus_warning_yaml)
 
   output:
   path ("*"), emit: multiqc

--- a/nextflow.config
+++ b/nextflow.config
@@ -52,7 +52,6 @@ params {
   bandage_templates = "${projectDir}/assets/bandage_templates"
   sequencing_summary = '' 
   pycoqc_header_file = "${projectDir}/assets/pycoqc_report_header.txt"
-  fallback_denovo = false
   max_contigs = ''
 }
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -52,6 +52,8 @@ params {
   bandage_templates = "${projectDir}/assets/bandage_templates"
   sequencing_summary = '' 
   pycoqc_header_file = "${projectDir}/assets/pycoqc_report_header.txt"
+  fallback_denovo = false
+  max_contigs = ''
 }
 
 // Fail a task if any command returns non-zero exit code


### PR DESCRIPTION
Autocycler would sometimes fail during the `autocycler compress` step if the genome assembly was too fragmented or contained too many contigs. In these cases, we may not want to fail the entire pipeline, but instead revert back to using the de novo assemblies.

Currently, I have implemented a failsafe by ignoring an exit status of `1` from `autocycler compress`. The existing downstream code already handles a missing consensus sequence for a sample and reverts to using the de novo assemblies for downstream analyses.

Other things to implement to make this a little more flexible:

- [x] Add a parameter to specify that the user is ok with the consensus failing. Default to failing the pipeline, but user can check the reason for the failure, decide they are happy to proceed with the de novo assemblies, and add e.g. `--fallback_denovo`
- [x] Expose `autocycler compress --max_contigs` parameter to allow more mean contigs per assembly. This would be useful when a genome contains many plasmids and isn't truly fragmented.
- [ ] ~Add more sophisticated error checking within `autocycler compress` script. Use `set +e` to allow `autocycler` to fail, then check the error code and log file to determine if it is due to exceeding `max_contigs` or not. If so, exit with status e.g. `127`, else `1` for any other error and `0` for success. Then change `errorStrategy` to `{ task.exitStatus == 127 && params.fallback_denovo ? 'ignore' : 'finish' }`~

One other question: is `exitStrategy 'finish'` ok to use, or should we keep the default of 'terminate'?