### PR TITLE
Add GFF3 output from bakta_annotation_chromosomes

### DIFF
--- a/modules/run_bakta_annotation_chromosomes.nf
+++ b/modules/run_bakta_annotation_chromosomes.nf
@@ -10,6 +10,7 @@ process bakta_annotation_chromosomes {
   output:
   tuple val(barcode), val(assembler), path("${prefix}.faa"), emit: faa
   tuple val(barcode), val(assembler), path("${prefix}.txt"), emit: txt
+  tuple val(barcode), val(assembler), path("${prefix}.gff3"), emit: gff
 
   script:
   prefix = "${barcode}_${assembler}_chr"

--- a/modules/run_bakta_annotation_plasmids.nf
+++ b/modules/run_bakta_annotation_plasmids.nf
@@ -9,7 +9,7 @@ input:
 
 output:
   tuple val(barcode), path("${barcode}_bakta/"), emit: bakta_annotations    
-  tuple val(barcode), path("${barcode}_bakta//${barcode}_plasmids.txt"), emit: bakta_annotations_multiqc
+  tuple val(barcode), path("${barcode}_bakta/${barcode}_plasmids.txt"), emit: bakta_annotations_multiqc
 
 script:
   """


### PR DESCRIPTION
Addressing issue #96 - adding the gff3 output from bakta when annotating chromosomes.

bakta for plasmids already outputs the entire output folder to the `publishDir`, including the gff3 file, so we don't need to worry about updating that. However, I did fix a double forward slash because it bugged me.