### PR TITLE
Rename MultiQC reports

### DIFF
--- a/modules/run_multiqc.nf
+++ b/modules/run_multiqc.nf
@@ -1,7 +1,7 @@
 process multiqc_report {
   tag "GENERATING SUMMARY REPORT"
   container 'quay.io/biocontainers/multiqc:1.21--pyhdfd78af_0'
-  publishDir "${params.outdir}/report", mode: 'copy'
+  publishDir "${params.outdir}/report/qc_report", mode: 'copy'
 
   input:
   path(pycoqc)

--- a/modules/run_multiqc_results.nf
+++ b/modules/run_multiqc_results.nf
@@ -1,7 +1,7 @@
 process multiqc_results_report {
   tag "GENERATING RESULTS SUMMARY REPORT"
   container 'quay.io/biocontainers/multiqc:1.21--pyhdfd78af_0'
-  publishDir "${params.outdir}/report/results", mode: 'copy'
+  publishDir "${params.outdir}/report/analysis_report", mode: 'copy'
 
   input:
   path(multiqc_results_config)


### PR DESCRIPTION
Addressing #97 

The MultiQC reports are currently organised like so:

- Sequencing QC: `results/report/{multiqc_data/,multiqc_report.html}`
- Results/analysis report: `results/report/results/{multiqc_data/,multiqc_report.html}`

This naming convention is a bit messy and might be a bit confusing, so this update moves them to:

- Sequencing QC: `results/report/qc_report/{multiqc_data/,multiqc_report.html}`
- Results/analysis report: `results/report/analysis_report/{multiqc_data/,multiqc_report.html}`