### PR TITLE
Add medaka to end of autocycler subworkflow

### DIFF
--- a/modules/run_medaka_polish_consensus.nf
+++ b/modules/run_medaka_polish_consensus.nf
@@ -4,16 +4,17 @@ process medaka_polish_consensus {
   publishDir "${params.outdir}/assemblies/${barcode}_consensus", mode: 'copy'
 
   input:
-  tuple val(barcode), path(cluster_dir)
+  tuple val(barcode), path(fastq), path(fasta)
 
   output:
-  tuple val(barcode), path("consensus.fasta"), emit: cluster_assembly
+  tuple val(barcode), path("consensus.fasta"), emit: polished_assembly
 
   script:
+  cluster_dir = fasta.getParent()
   """
   medaka_consensus \\
-    -i ${cluster_dir}/4_reads.fastq \\
-    -d ${cluster_dir}/7_final_consensus.fasta \\
+    -i ${fastq} \\
+    -d ${fasta} \\
     -o ./ \\
     -t ${task.cpus}
   """

--- a/subworkflows/trycycler.nf
+++ b/subworkflows/trycycler.nf
@@ -178,19 +178,19 @@ workflow trycycler {
     trycycler_consensus(clusters_for_consensus)
 
     // MEDAKA: Polish consensus assembly
-    consensus_dir = 
+    consensus_to_polish = 
         // Get parent dir for assembly
         trycycler_consensus.out.cluster_assembly
-        .map { barcode, assembly ->
-            Path assembly_dir = assembly.getParent()
-            return [barcode, assembly_dir]
+        .map { barcode, assembly_fasta ->
+            def assembly_fastq = assembly_fasta.getParent() / '4_reads.fastq'
+            return [barcode, assembly_fastq, assembly_fasta]
         }
 
-    medaka_polish_consensus(consensus_dir)
+    medaka_polish_consensus(consensus_to_polish)
 
     // CAT: Combine polished clusters consensus assemblies into a single fasta
     polished_clusters = 
-        medaka_polish_consensus.out.cluster_assembly
+        medaka_polish_consensus.out.polished_assembly
         .groupTuple()
         .map { barcode, fastas ->
             // Need to avoid filename collisions with consensus.fasta files


### PR DESCRIPTION
Addressing issue #104 

Currently, the autocycler subworkflow doesn't polish the consensus assemblies with medaka. This update adds the medaka step to the end of the subworkflow and outputs the polished consensus rather than the raw consensus.